### PR TITLE
override bootstrap floating using !important on smaller breakpoints

### DIFF
--- a/scss/project/project_template.scss
+++ b/scss/project/project_template.scss
@@ -204,12 +204,19 @@ li .nav-item {
         flex-wrap: nowrap;
     }
 
-    /* overwrite the bootstrap class to remove the right margin on images */
+    // /* overwrite the bootstrap class to remove the right margin on images */
     img.me-5 {
-        margin-right: 0 !important;
+        margin-right: auto !important; // the important is necessary here since otherwise, the bootstrap isn't overridden
     }
 
     .max-height-override {
         max-height: 100% !important;
     }
+
+    // override the floating images on smaller screens to avoid wrapping breaking of text 
+
+    img.float-end {
+        float: none !important; // the important is necessary here since otherwise, the bootstrap isn't overridden
+    }
+
 }


### PR DESCRIPTION
![image](https://github.com/uci-ieee/ops-webpages-2023-2024/assets/75911565/47af200b-4564-4709-b0a4-4a00a4333848)
