### PR TITLE
Set nested navs in sbar to flex-col, deleted extra ul

### DIFF
--- a/project_3.html
+++ b/project_3.html
@@ -59,7 +59,7 @@
                     <li class="nav-item">
 						<a class="nav-link" href="#pj-heading-concepts">Concepts</a>
 
-						<ul class="nav">
+						<ul class="nav flex-column">
                             <li class="nav-item">
 								<a class="nav-link" href="#pj-heading-cpp">C++ Programming Language</a>
 							</li>
@@ -73,7 +73,7 @@
 					</li>
 					<li class="nav-item">
 						<a class="nav-link" href="#pj-heading-ide-setup">IDE Setup</a>
-						<ul class="nav">
+						<ul class="nav flex-column">
                             <li class="nav-item">
 								<a class="nav-link" href="#pj-heading-replit">Replit</a>
 							</li>
@@ -81,7 +81,7 @@
 					</li>
 					<li class="nav-item">
 						<a class="nav-link" href="#pj-heading-requirements">Requirements</a>
-						<ul class="nav">
+						<ul class="nav flex-column">
 							<li class="nav-item">
 								<a class="nav-link" href="#pj-heading-echo">Echo</a>
 							</li>
@@ -99,9 +99,9 @@
 							</li>
 						</ul>
 					</li>
-						<li class="nav-item">
-							<a class="nav-link" href="#pj-heading-instructions">Instructions</a>
-						</li>
+					<li class="nav-item">
+						<a class="nav-link" href="#pj-heading-instructions">Instructions</a>
+					</li>
 					<li class="nav-item">
 						<a class="nav-link" href="#pj-heading-deliverables">Deliverables</a>
 					</li>
@@ -271,45 +271,43 @@
 
 
 			<h3 class="mb-3" id="pj-heading-take-the-average">Take the Average</h3>
+			<ul class="mb-5 list-group">
 				<li class="list-group-item">
-					<ul class="mb-5 list-group">
-						<li class="list-group-item">
-							Function Header: <code class="pj-code language-arduino">double avg(int arr[], int size)</code>	
-						</li>
-						<li class="list-group-item">
-							Parameters: arr (int array), size (int)
-						</li>
-						<li class="list-group-item">
-							Return: double
-						</li>
-						<li class="list-group-item">
-							Description: <code class="pj-code language-arduino">avg()</code> returns the mean of the elements in the array <code class="pj-code language-arduino">arr</code>. The array must not be mutated by the function. Its elements may be positive or negative.
-						</li>
-					</ul>
+					Function Header: <code class="pj-code language-arduino">double avg(int arr[], int size)</code>	
 				</li>
+				<li class="list-group-item">
+					Parameters: arr (int array), size (int)
+				</li>
+				<li class="list-group-item">
+					Return: double
+				</li>
+				<li class="list-group-item">
+					Description: <code class="pj-code language-arduino">avg()</code> returns the mean of the elements in the array <code class="pj-code language-arduino">arr</code>. The array must not be mutated by the function. Its elements may be positive or negative.
+				</li>
+			</ul>
 
 			<h3 class="mb-3" id="pj-heading-fib-seq">Fibonacci Sequence</h3>
-				<ul class="mb-3 list-group">
-						<li class="list-group-item">
-							Function Header: <code class="pj-code language-arduino">void fib(unsigned n)</code>
-						</li>
-						<li class="list-group-item">
-							Parameters: n (unsigned int)
-						</li>
-						<li class="list-group-item">
-							Return: None
-						</li>
-						<li class="list-group-item">
-							Description: <code class="pj-code language-arduino">fib()</code> prints the first n elements of the Fibonacci sequence to the console. Each element should be separated by a comma and one space. The last element terminates the line without a space or comma. <code class="pj-code language-arduino">n > 0</code>
-						</li>
-						<li class="list-group-item">
-							Examples:
-								<ul>
-									<li><code class="pj-code language-arduino">fib(1) : 1</code></li>
-									<li><code class="pj-code language-arduino">fib(4) : 1, 1, 2, 3</code></li>
-								</ul>
-						</li>
-					</ul>
+			<ul class="mb-3 list-group">
+				<li class="list-group-item">
+					Function Header: <code class="pj-code language-arduino">void fib(unsigned n)</code>
+				</li>
+				<li class="list-group-item">
+					Parameters: n (unsigned int)
+				</li>
+				<li class="list-group-item">
+					Return: None
+				</li>
+				<li class="list-group-item">
+					Description: <code class="pj-code language-arduino">fib()</code> prints the first n elements of the Fibonacci sequence to the console. Each element should be separated by a comma and one space. The last element terminates the line without a space or comma. <code class="pj-code language-arduino">n > 0</code>
+				</li>
+				<li class="list-group-item">
+					Examples:
+						<ul>
+							<li><code class="pj-code language-arduino">fib(1) : 1</code></li>
+							<li><code class="pj-code language-arduino">fib(4) : 1, 1, 2, 3</code></li>
+						</ul>
+				</li>
+				</ul>
 
 
 			


### PR DESCRIPTION
- Fixes the two nav items in the sidebar which sat in the same row (result of parent container being a flex-row)
- Fixes incorrect indentation of list associated with "Take the Average" in the Requirements section