### PR TITLE
121 cache busting for css files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ css/custom.css.map
 # cache-busted js files, the intention here is to ignore stuff like: js/collapsible.d3c8b399d90e9e13ef46d598f53a05ca.js
 # however, if we use actual js files like js/card.test.js, then it will be ignored. This is just here in case someone runs the cache-busting script on accident locally.
 js/*.*.js
+
+# ignore cache-busted css files
+css/*.*.css

--- a/scripts/hash.js
+++ b/scripts/hash.js
@@ -7,9 +7,14 @@ const directoryPath = __dirname + "/../"; // Use the current directory
 // here is where all the javascript files live
 const jsPath = directoryPath + "/js/";
 
+// here is where all the css files live
+const cssPath = directoryPath + "/css";
+
 // generate a hash map of js files and create copies of the JS file with the hash in the name
-const jsHashMap = hashHelpers.createHashMapOfJSFiles(jsPath);
+const jsHashMap = hashHelpers.createHashMapOfFiles(jsPath, "js");
 console.log(jsHashMap);
+const cssHashMap = hashHelpers.createHashMapOfFiles(cssPath, "css")
+console.log(cssHashMap);
 
 // get a list of all the HTML files in the directory
 const htmlFiles = hashHelpers.getHtmlFilePaths(directoryPath);
@@ -17,3 +22,6 @@ console.log(htmlFiles)
 
 // iterate through all the html files and update the javascript
 hashHelpers.updateHTMLFiles(htmlFiles, jsHashMap);
+
+// update the css
+hashHelpers.updateHTMLFiles(htmlFiles, cssHashMap);

--- a/scripts/hash.js
+++ b/scripts/hash.js
@@ -8,7 +8,7 @@ const directoryPath = __dirname + "/../"; // Use the current directory
 const jsPath = directoryPath + "/js/";
 
 // here is where all the css files live
-const cssPath = directoryPath + "/css";
+const cssPath = directoryPath + "/css/";
 
 // generate a hash map of js files and create copies of the JS file with the hash in the name
 const jsHashMap = hashHelpers.createHashMapOfFiles(jsPath, "js");

--- a/scripts/hashHelpers.js
+++ b/scripts/hashHelpers.js
@@ -128,4 +128,4 @@ function getHtmlFilePaths(directoryPath) {
     return htmlFiles;
 }
 
-module.exports = { getHtmlFilePaths, createHashMapOfJSFiles, updateHTMLFiles };
+module.exports = { getHtmlFilePaths, createHashMapOfFiles, updateHTMLFiles };

--- a/scripts/hashHelpers.js
+++ b/scripts/hashHelpers.js
@@ -33,7 +33,7 @@ function createHashMapOfFiles(directoryPath, fileExtension) {
     const files = fs.readdirSync(directoryPath);
 
     // make sure the fileExtension does not start with a dot. If so, remove it.
-    if (fileExtension.startsWith(".")) {
+    if (fileExtension.at(0) === ".") {
         fileExtension = fileExtension.slice(1);
     }
 

--- a/scripts/hashHelpers.js
+++ b/scripts/hashHelpers.js
@@ -67,7 +67,7 @@ function createHashMapOfFiles(directoryPath, fileExtension) {
 
 
 /**
- * update the html content to include the hashed js
+ * update the html content to include the hashed file names
  * @param {*} htmlFiles a list of html file paths to update
  * @param {*} fileHashMap the map of the unhashed file names to the hashed name
  */

--- a/scripts/hashHelpers.js
+++ b/scripts/hashHelpers.js
@@ -42,7 +42,7 @@ function createHashMapOfFiles(directoryPath, fileExtension) {
         if (fs.statSync(filePath).isDirectory()) {
             // if the current file is a directory
             // recursively call the function for that directory and add it to the current running array of html files
-            filesMap = { ...filesMap, ...createHashMapOfFiles(filePath) };
+            filesMap = { ...filesMap, ...createHashMapOfFiles(filePath, fileExtension) };
         } else {
             // If it is a file, check if it is an HTML file
             if (path.extname(file).toLowerCase() === `.${fileExtension}`) {

--- a/scripts/hashHelpers.js
+++ b/scripts/hashHelpers.js
@@ -10,43 +10,49 @@ const path = require('path');
  * @param {*} filePath 
  * @returns 
  */
-function createHashOfJS(filePath) {
+function createHashOfFile(filePath) {
     console.log(filePath)
     const fileContent = fs.readFileSync(filePath);
     return crypto.createHash('md5').update(fileContent).digest('hex');
 }
 
 /**
- * generate a hash of all the js files in the js directory, also creating a copy of the file with the hashed name
- * @param {*} directoryPath where all the javascript files that should be hashed live
- * @returns javascript object keyed by the original javascript file name and the new hashed file name
+ * generate a hash of all the files in the specified directory, also creating a copy of the file with the hashed name
+ * @param {*} directoryPath where all the files that should be hashed live
+ * @param {*} fileExtension the extension of the files. For example, "js", "css", etc. **omit the dot**.
+ * @returns javascript object keyed by the original file name and the new hashed file name
  */
-function createHashMapOfJSFiles(directoryPath) {
+function createHashMapOfFiles(directoryPath, fileExtension) {
     // recursively iterate through every js file in this directory to hash
 
-    let jsFiles = {};
+    let filesMap = {};
 
     // for each file in the directory
 
     // read directory
     const files = fs.readdirSync(directoryPath);
 
+    // make sure the fileExtension does not start with a dot. If so, remove it.
+    if (fileExtension.startsWith(".")) {
+        fileExtension = fileExtension.slice(1);
+    }
+
     for (const file of files) {
         const filePath = path.join(directoryPath, file);
         if (fs.statSync(filePath).isDirectory()) {
             // if the current file is a directory
             // recursively call the function for that directory and add it to the current running array of html files
-            jsFiles = { ...jsFiles, ...createHashMapOfJSFiles(filePath) };
+            filesMap = { ...filesMap, ...createHashMapOfFiles(filePath) };
         } else {
             // If it is a file, check if it is an HTML file
-            if (path.extname(file).toLowerCase() === '.js') {
+            if (path.extname(file).toLowerCase() === `.${fileExtension}`) {
                 // grab the js base
                 const fileName = file.split(".").slice(0, -1).join(".");
-                const hash = createHashOfJS(filePath);
-                const newFileName = `${fileName}.${hash}.js`;
+                const hash = createHashOfFile(filePath);
+                const newFileName = `${fileName}.${hash}.${fileExtension}`;
 
                 // add it to the map
-                jsFiles[file] = newFileName;
+                filesMap[file] = newFileName;
 
                 // copy the content of the original js to the new js file with the name
                 const newFilePath = path.join(directoryPath, newFileName);
@@ -56,22 +62,22 @@ function createHashMapOfJSFiles(directoryPath) {
     }
 
     // return the map
-    return jsFiles;
+    return filesMap;
 }
 
 
 /**
  * update the html content to include the hashed js
  * @param {*} htmlFiles a list of html file paths to update
- * @param {*} jsFileHashMap the map of the unhashed javascript file names to the hashed javascript name
+ * @param {*} fileHashMap the map of the unhashed file names to the hashed name
  */
-function updateHTMLFiles(htmlFiles, jsFileHashMap) {
+function updateHTMLFiles(htmlFiles, fileHashMap) {
     for (file of htmlFiles) {
         // read the file contents
         let htmlContent = fs.readFileSync(file, 'utf-8');
         // update all the JS files
         // NOTE: this is a bit circular
-        for (const [jsFileName, jsHashedFileName] of Object.entries(jsFileHashMap)) {
+        for (const [jsFileName, jsHashedFileName] of Object.entries(fileHashMap)) {
             console.log(`searching for ${jsFileName} in ${file}`)
             updatedHtml = htmlContent.replaceAll(jsFileName, jsHashedFileName);
             if (updatedHtml !== htmlContent) {

--- a/scripts/hashHelpers.js
+++ b/scripts/hashHelpers.js
@@ -2,11 +2,11 @@ const fs = require("fs");
 const crypto = require("crypto");
 const path = require('path');
 
-// this function defines helper functions used in hash.js to implement cache busting of js files
+// this function defines helper functions used in hash.js to implement cache busting of cached files
 
 
 /**
- * given a js file path, generate an md5 hash
+ * given a file path, generate an md5 hash from the content
  * @param {*} filePath 
  * @returns 
  */
@@ -23,7 +23,7 @@ function createHashOfFile(filePath) {
  * @returns javascript object keyed by the original file name and the new hashed file name
  */
 function createHashMapOfFiles(directoryPath, fileExtension) {
-    // recursively iterate through every js file in this directory to hash
+    // recursively iterate through every file in this directory to hash
 
     let filesMap = {};
 
@@ -46,7 +46,7 @@ function createHashMapOfFiles(directoryPath, fileExtension) {
         } else {
             // If it is a file, check if it is an HTML file
             if (path.extname(file).toLowerCase() === `.${fileExtension}`) {
-                // grab the js base
+                // grab the file base
                 const fileName = file.split(".").slice(0, -1).join(".");
                 const hash = createHashOfFile(filePath);
                 const newFileName = `${fileName}.${hash}.${fileExtension}`;
@@ -54,7 +54,7 @@ function createHashMapOfFiles(directoryPath, fileExtension) {
                 // add it to the map
                 filesMap[file] = newFileName;
 
-                // copy the content of the original js to the new js file with the name
+                // copy the content of the original file to the new file with the name
                 const newFilePath = path.join(directoryPath, newFileName);
                 fs.copyFileSync(filePath, newFilePath);
             }
@@ -75,16 +75,16 @@ function updateHTMLFiles(htmlFiles, fileHashMap) {
     for (file of htmlFiles) {
         // read the file contents
         let htmlContent = fs.readFileSync(file, 'utf-8');
-        // update all the JS files
+        // update all the files
         // NOTE: this is a bit circular
-        for (const [jsFileName, jsHashedFileName] of Object.entries(fileHashMap)) {
-            console.log(`searching for ${jsFileName} in ${file}`)
-            updatedHtml = htmlContent.replaceAll(jsFileName, jsHashedFileName);
+        for (const [fileName, hashedFileName] of Object.entries(fileHashMap)) {
+            console.log(`searching for ${fileName} in ${file}`)
+            updatedHtml = htmlContent.replaceAll(fileName, hashedFileName);
             if (updatedHtml !== htmlContent) {
-                console.log(`${jsFileName} was found and replaced with ${jsHashedFileName}`);
+                console.log(`${fileName} was found and replaced with ${hashedFileName}`);
                 htmlContent = updatedHtml;
             } else {
-                console.log(`${jsFileName} was not found in ${file}`)
+                console.log(`${fileName} was not found in ${file}`)
             }
         }
         fs.writeFileSync(file, htmlContent, 'utf-8');


### PR DESCRIPTION
![image](https://github.com/uci-ieee/ops-webpages-2023-2024/assets/75911565/4f6eb60c-7622-4818-ba5e-fe3616598890)


I think it works. I subsequently checked the workshop.html and index.html and styling seemed ok?

Note: if you run `npm run cache-busting` locally, there will be a bunch of unignored css files in `css/highlight.js` as my .gitignore pattern matching wasn't good enough to catch it.

I generalized the hashing function to work for any directory and file extension, and updated the variable names and comments for clarity