### PR TITLE
Project 7: Fixed typos

### DIFF
--- a/project_7.html
+++ b/project_7.html
@@ -117,8 +117,8 @@
 					</div>
 					<div class="alert alert-light" role="alert">
 						<i class="bi bi-calendar-event me-1"></i>
-						Updated 2024.02.15 <br>
-						By Benjamen Bielecki
+						Updated 2024.04.07 <br>
+						By Colton Kaneria
 					</div>
 				</div>
 
@@ -235,7 +235,7 @@
 						<td>
 							<code class="pj-code language-arduino">timer.stop();</code>
 						</td>
-						<td>Stops the timer; ; in this <code class="pj-code language-arduino">PAUSED</code> state,
+						<td>Stops the timer; in this <code class="pj-code language-arduino">STOPPED</code> state,
 							the next call to <code class="pj-code language-arduino">timer.stop()</code>
 							resets the timer</td>
 					</tr>
@@ -253,7 +253,7 @@
 						<td>Returns the state of the timer as one of three constants: <code
 								class="pj-code language-arduino">RUNNING</code>, <code
 								class="pj-code language-arduino">PAUSED</code>, and <code
-								class="pj-code language-arduino">STOPOPED</code></td>
+								class="pj-code language-arduino">STOPPED</code></td>
 					</tr>
 				</table>
 				</p>


### PR DESCRIPTION
- Removed extra semicolon from timer.stop() line
- Changed state for timer.stop() to STOPPED instead of PAUSED
- Changed STOPOPED to STOPPED in the last line of the timer function table.